### PR TITLE
Change how `accessToken` is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ yarn add @arcadia-eng/utility-connect-react
 
 ## Quick start
 
+#### accessToken
+
+This is the token used to authenticate API requests. It will be passed to the `open()` function used to open the module. If you are integrating with this package you should have instructions on how to generate tokens for your client. Note that the type of `accessToken` needed to instantiate the component depends on the "user flow" i.e. `create` vs. `update`
+
 ### Hook implementation
 
 This is the recommended implementation strategy. See [/examples/hooks.js](./examples/hook.js) for a full example with callback functions defined. Note the required configuration options [below](#config-options).
@@ -31,7 +35,7 @@ const CreateCredentials = props => {
   const [{ loading, error }, open] = useUtilityConnect(config);
 
   return (
-    <button type="button" disabled={loading} onClick={() => open()}>
+    <button type="button" disabled={loading} onClick={() => open(accessToken)}>
       Connect credentials
     </button>
   );
@@ -59,7 +63,7 @@ class CreateCredentials extends React.Component {
     const { ready, error, open } = this.utilityConnect;
 
     return (
-      <button type="button" disabled={ready} onClick={() => open()}>
+      <button type="button" disabled={ready} onClick={() => open(accessToken)}>
         Connect credentials
       </button>
     );
@@ -77,15 +81,14 @@ Please note that this package is still under active development and has yet to r
 
 ### Config options
 
-| Name          | Type     | Description                                | Options                              | Required | Default  |
-| ------------- | -------- | ------------------------------------------ | ------------------------------------ | -------- | -------- |
-| `scope`       | `string` | User flow type                             | `['create', 'update']`               | No       | 'create' |
-| `env`         | `string` | API environment                            | `['local', 'staging', 'production']` | Yes      | none     |
-| `accessToken` | `string` | API token for authenticating requests      |                                      | Yes      | none     |
-| `client`      | `string` | Name used to reference organization in app |                                      | Yes      | none     |
-| `data`        | `object` | Data passed to the api                     |                                      | Yes      | none     |
-| `callbacks`   | `object` | Callback functions                         |                                      | No       | none     |
-| `uiTheme`     | `string` | UI color theme                             | `['light', 'dark']`                  | No       | 'light'  |
+| Name        | Type     | Description                                | Options                              | Required | Default  |
+| ----------- | -------- | ------------------------------------------ | ------------------------------------ | -------- | -------- |
+| `scope`     | `string` | User flow type                             | `['create', 'update']`               | No       | 'create' |
+| `env`       | `string` | API environment                            | `['local', 'staging', 'production']` | Yes      | none     |
+| `client`    | `string` | Name used to reference organization in app |                                      | Yes      | none     |
+| `data`      | `object` | Data passed to the api                     |                                      | Yes      | none     |
+| `callbacks` | `object` | Callback functions                         |                                      | No       | none     |
+| `uiTheme`   | `string` | UI color theme                             | `['light', 'dark']`                  | No       | 'light'  |
 
 #### scope
 
@@ -101,10 +104,6 @@ Determines which API the Utility Connect front-end points to
 - `local`: Use this if you are interfacing with a local API. **You will almost never need this option.**
 - `staging`: This references our staging API. Use this in your development and staging environments.
 - `production`: This references our production API. **Only use this in your production app.**
-
-#### accessToken
-
-This is the token used to authenticate API requests. If you are integrating with this tool you should have instructions on how to generate tokens for your client. Note that the type of `accessToken` needed to instantiate the component depends on the "user flow."
 
 #### `create` scope
 

--- a/examples/hoc.js
+++ b/examples/hoc.js
@@ -5,7 +5,6 @@ import { withUtilityConnect } from '@arcadia-eng/utility-connect-react';
 const config = {
   env: 'staging',
   client: 'Test Co.',
-  accessToken: 'this_is_a_super_secret_token',
 };
 
 const data = {
@@ -60,7 +59,11 @@ class CreateCredentials extends React.Component {
     }
 
     return (
-      <button type="button" disabled={ready} onClick={() => open()}>
+      <button
+        type="button"
+        disabled={ready}
+        onClick={() => open('this_is_a_super_secret_token')}
+      >
         Connect credentials
       </button>
     );

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -1,7 +1,6 @@
 import { useUtilityConnect } from '@arcadia-eng/utility-connect-react';
 
 const env = 'staging';
-const accessToken = 'this_is_a_super_secret_token';
 const client = 'Test Co.';
 
 const data = {
@@ -33,7 +32,6 @@ const CreateCredentials = props => {
 
   const config = {
     env,
-    accessToken,
     client,
     data,
     callbacks,
@@ -47,7 +45,11 @@ const CreateCredentials = props => {
   }
 
   return (
-    <button type="button" disabled={loading} onClick={() => open()}>
+    <button
+      type="button"
+      disabled={loading}
+      onClick={() => open('this_is_a_super_secret_token')}
+    >
       Connect credentials
     </button>
   );

--- a/src/use-utility-connect.js
+++ b/src/use-utility-connect.js
@@ -39,12 +39,14 @@ export const useUtilityConnect = config => {
     if (scriptError) setError(scriptLoadError);
   }, [scriptError, setError]);
 
-  const open = async () => {
+  const open = async accessToken => {
     if (!factory) return;
 
     setLoading(true);
     try {
-      const configErrors = await factory.validate(config);
+      const args = { ...config, accessToken };
+
+      const configErrors = await factory.validate(args);
       if (configErrors) {
         setError(getConfigError(configErrors));
       } else {
@@ -53,8 +55,8 @@ export const useUtilityConnect = config => {
           setUtilityConnect(undefined);
         };
 
-        const callbacks = { ...(config.callbacks || {}), onClose };
-        const utilityConnect = factory.create({ ...config, callbacks });
+        const callbacks = { ...(args.callbacks || {}), onClose };
+        const utilityConnect = factory.create({ ...args, callbacks });
         setUtilityConnect(utilityConnect);
       }
       setLoading(false);


### PR DESCRIPTION
When working on the demo app, it felt more appropriate to pass the `accessToken` through to the widget WHEN we wanted to open the widget as opposed to in an initial configuration. 

In the previous implementation, we were defining the `accessToken` in the config which is defined before we ever try to open the widget. Theoretically the `accessToken` could expire before a user ever opens the widget.

This new implementation allows end users to obtain and pass through a token when the user is ready to start the flow. 

i.e. 

```javascript
const [{ loading, error }, open] = useUtilityConnect(config);

const openWidget = () => {
  getComponentToken()
    .then(token => {
      open(token);
    })
    .catch((error) => {
      handleError(error)
    });
};

return (
  <Button disabled={loading} onClick={() => openWidget()}>
    Connect Credentials
  </Button>  
);
```