### PR TITLE
Update how config is passed through to the useUtilityConnect hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ import { useUtilityConnect } from '@arcadia-eng/utility-connect-react';
 const CreateCredentials = props => {
   const config = { ... };
 
-  const [{ loading, error }, open] = useUtilityConnect(config);
+  const [{ loading, error }, open] = useUtilityConnect();
 
   return (
-    <button type="button" disabled={loading} onClick={() => open(accessToken)}>
+    <button type="button" disabled={loading} onClick={() => open(config)}>
       Connect credentials
     </button>
   );
@@ -63,7 +63,7 @@ class CreateCredentials extends React.Component {
     const { ready, error, open } = this.utilityConnect;
 
     return (
-      <button type="button" disabled={ready} onClick={() => open(accessToken)}>
+      <button type="button" disabled={ready} onClick={() => open(config)}>
         Connect credentials
       </button>
     );
@@ -81,14 +81,15 @@ Please note that this package is still under active development and has yet to r
 
 ### Config options
 
-| Name        | Type     | Description                                | Options                              | Required | Default  |
-| ----------- | -------- | ------------------------------------------ | ------------------------------------ | -------- | -------- |
-| `scope`     | `string` | User flow type                             | `['create', 'update']`               | No       | 'create' |
-| `env`       | `string` | API environment                            | `['local', 'staging', 'production']` | Yes      | none     |
-| `client`    | `string` | Name used to reference organization in app |                                      | Yes      | none     |
-| `data`      | `object` | Data passed to the api                     |                                      | Yes      | none     |
-| `callbacks` | `object` | Callback functions                         |                                      | No       | none     |
-| `uiTheme`   | `string` | UI color theme                             | `['light', 'dark']`                  | No       | 'light'  |
+| Name          | Type     | Description                                | Options                              | Required | Default  |
+| ------------- | -------- | ------------------------------------------ | ------------------------------------ | -------- | -------- |
+| `scope`       | `string` | User flow type                             | `['create', 'update']`               | No       | 'create' |
+| `env`         | `string` | API environment                            | `['local', 'staging', 'production']` | Yes      | none     |
+| `accessToken` | `string` | API token for authenticating requests      |                                      | Yes      | none     |
+| `client`      | `string` | Name used to reference organization in app |                                      | Yes      | none     |
+| `data`        | `object` | Data passed to the api                     |                                      | Yes      | none     |
+| `callbacks`   | `object` | Callback functions                         |                                      | No       | none     |
+| `uiTheme`     | `string` | UI color theme                             | `['light', 'dark']`                  | No       | 'light'  |
 
 #### scope
 
@@ -112,6 +113,10 @@ The component needs a standard server-side generated access token. More details 
 #### `update` scope
 
 The `accessToken` must be scoped to the user in order to update a user's utility credentials. More details on creating scoped tokens can be found in the [API documentation](https://arcadiapower.github.io/enterprise-api/).
+
+#### accessToken
+
+This is the token used to authenticate API requests. If you are integrating with this tool you should have instructions on how to generate tokens for your client. Note that the type of `accessToken` needed to instantiate the component depends on the "user flow."
 
 #### client
 

--- a/examples/hoc.js
+++ b/examples/hoc.js
@@ -5,6 +5,7 @@ import { withUtilityConnect } from '@arcadia-eng/utility-connect-react';
 const config = {
   env: 'staging',
   client: 'Test Co.',
+  accessToken: 'this_is_a_super_secret_token',
 };
 
 const data = {
@@ -59,11 +60,7 @@ class CreateCredentials extends React.Component {
     }
 
     return (
-      <button
-        type="button"
-        disabled={ready}
-        onClick={() => open('this_is_a_super_secret_token')}
-      >
+      <button type="button" disabled={ready} onClick={() => open(config)}>
         Connect credentials
       </button>
     );

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -2,6 +2,7 @@ import { useUtilityConnect } from '@arcadia-eng/utility-connect-react';
 
 const env = 'staging';
 const client = 'Test Co.';
+const accessToken = 'this_is_a_super_secret_token';
 
 const data = {
   user: {
@@ -38,18 +39,14 @@ const CreateCredentials = props => {
     scope: 'create',
   };
 
-  const [{ loading, error }, open] = useUtilityConnect(config);
+  const [{ loading, error }, open] = useUtilityConnect();
 
   if (error) {
     return <div>Failed to load credential widget: {error.message}</div>;
   }
 
   return (
-    <button
-      type="button"
-      disabled={loading}
-      onClick={() => open('this_is_a_super_secret_token')}
-    >
+    <button type="button" disabled={loading} onClick={() => open(config)}>
       Connect credentials
     </button>
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "0.0.1-alpha.8",
+  "version": "0.0.1-alpha.9",
   "description": "React tool for integrating with Arcadia's utility connect service",
   "main": "dist/index.js",
   "scripts": {

--- a/src/use-utility-connect.js
+++ b/src/use-utility-connect.js
@@ -13,7 +13,7 @@ const getConfigError = errors => {
   return new Error(`Error setting configuration variables: ${message}`);
 };
 
-export const useUtilityConnect = config => {
+export const useUtilityConnect = () => {
   const [error, setError] = useState();
   const [loading, setLoading] = useState(false);
   const [factory, setFactory] = useState();
@@ -39,14 +39,12 @@ export const useUtilityConnect = config => {
     if (scriptError) setError(scriptLoadError);
   }, [scriptError, setError]);
 
-  const open = async accessToken => {
+  const open = async config => {
     if (!factory) return;
 
     setLoading(true);
     try {
-      const args = { ...config, accessToken };
-
-      const configErrors = await factory.validate(args);
+      const configErrors = await factory.validate(config);
       if (configErrors) {
         setError(getConfigError(configErrors));
       } else {
@@ -55,8 +53,8 @@ export const useUtilityConnect = config => {
           setUtilityConnect(undefined);
         };
 
-        const callbacks = { ...(args.callbacks || {}), onClose };
-        const utilityConnect = factory.create({ ...args, callbacks });
+        const callbacks = { ...(config.callbacks || {}), onClose };
+        const utilityConnect = factory.create({ ...config, callbacks });
         setUtilityConnect(utilityConnect);
       }
       setLoading(false);


### PR DESCRIPTION
We don't actually validate the contents of the config UNTIL we invoke the `open()` callback function.

It seems a bit weird then to require the config before this point...especially since we decided that the `accessToken`, which is expirable, should be passed in at the time the widget opens. 

This simplifies the logic here `src/use-utility-connect.js`

Went ahead and tested with the Enterprise demo by building the package and copying over the `index.js` into our node modules 👍 