### PR TITLE
[EN-227] Allow queuing of open function before loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React tool for integrating with Arcadia's utility connect service",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
https://arcadiapower.atlassian.net/browse/EN-227

### How to test:

Move the compiled version of utility-connect-react to the enterprise demo repo.

I updated the [enterprise-demo-app](https://github.com/ArcadiaPower/enterprise-demo/blob/96510128f2334ce4397333c030911682a0c95997/src/components/utility-connect-widget.jsx#L62-L63) to have this right before the render:

```
  useEffect(() => {
    openWidget();
      }, []);
```
I also had to update the environment from `staging` to `sandbox`.