### PR TITLE
[EN-257] Clean up Utility Connect HOC, add test coverage, and standardize error type in hook

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
   "parser": "babel-eslint",
   "extends": [
     "prettier",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:jest-dom/recommended"
   ],
   "plugins": [
     "prettier"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,8 @@
 ## 0.0.1
 
 Internal testing version
+
+## 3.0.0
+
+- Errors in `use-utility-connect` now return a consistent `Error` object
+- `with-utility-connect` now matches the current implementation of `use-utility-connect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ Internal testing version
 
 - Errors in `use-utility-connect` now return a consistent `Error` object
 - `with-utility-connect` now matches the current implementation of `use-utility-connect`
+  - **Breaking Change**: The `ready` prop is no longer passed down by the HOC. Please use `loading` instead.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ yarn add @arcadia-eng/utility-connect-react
 
 # Quick Start
 
-The Utility Connect widget can be instantiated for one of two user flows: 
+The Utility Connect widget can be instantiated for one of two user flows:
+
 1. creating a new User (obtaining their credentials for the first time)
-2. updating an existing User (changing their credentials if Arcadia no longer has correct credentials). 
+2. updating an existing User (changing their credentials if Arcadia no longer has correct credentials).
 
 The user flow is selected with the `config.scope` parameter described in the component API Reference below.
 
@@ -61,7 +62,7 @@ const config = { ... }; // See "Config Options" in the API Reference
 
 class CreateCredentials extends React.Component {
   render() {
-    const { loading, error, open } = this.utilityConnect;
+    const { loading, error, open } = this.props.utilityConnect;
 
     return (
       <button type="button" disabled={loading} onClick={() => open(config)}>
@@ -71,24 +72,24 @@ class CreateCredentials extends React.Component {
   }
 }
 
-export default withUtilityConnect(CreateCredentials, config);
+export default withUtilityConnect(CreateCredentials);
 ```
 
-# API Reference 
+# API Reference
 
 Please note that this package is still under active development and the API is subject to change.
 
 ## Config Options
 
-| Name          | Type     | Description                                | Options                              | Required | Default  |
-| ------------- | -------- | ------------------------------------------ | ------------------------------------ | -------- | -------- |
-| `scope`       | `string` | User flow type                             | `['create', 'update']`               | No       | 'create' |
-| `data`        | `object` | Data passed to the API                     | Content depends on value of `scope`  | Yes      | none     |
+| Name          | Type     | Description                                                                   | Options                              | Required | Default  |
+| ------------- | -------- | ----------------------------------------------------------------------------- | ------------------------------------ | -------- | -------- |
+| `scope`       | `string` | User flow type                                                                | `['create', 'update']`               | No       | 'create' |
+| `data`        | `object` | Data passed to the API                                                        | Content depends on value of `scope`  | Yes      | none     |
 | `accessToken` | `string` | API [OAuth token](https://developers.arcadia.com/#operation/createOAuthToken) |                                      | Yes      | none     |
-| `env`         | `string` | API environment                            | `['local', 'sandbox', 'production']` | Yes      | none     |
-| `client`      | `string` | Name used to reference organization in app |                                      | Yes      | none     |
-| `callbacks`   | `object` | Callback functions                         |                                      | No       | none     |
-| `uiTheme`     | `string` | UI color theme                             | `['light', 'dark']`                  | No       | 'light'  |
+| `env`         | `string` | API environment                                                               | `['local', 'sandbox', 'production']` | Yes      | none     |
+| `client`      | `string` | Name used to reference organization in app                                    |                                      | Yes      | none     |
+| `callbacks`   | `object` | Callback functions                                                            |                                      | No       | none     |
+| `uiTheme`     | `string` | UI color theme                                                                | `['light', 'dark']`                  | No       | 'light'  |
 
 ### `config.scope`
 
@@ -96,7 +97,6 @@ Specifies the user flow. Defaults to `create`.
 
 - `create`: Opens the Utility Connect service in the "create user" flow - input credentials will be used to create a user and corresponding utility credential record.
 - `update`: Opens the Utility Connect service in the "update utility credentials" flow - input credentials will be used to update an existing utility credential record. This flow requires that you add `user.id` and `utilityCredential.id` into the `data` object.
-
 
 ### `config.data`
 
@@ -119,14 +119,13 @@ Example `config.data` when in the "creating user" flow:
 
 Data is expected in the following format for the `create` scope:
 
-| Data field | Description       | Required |
-| --------------------- | ----------------- | -------- |
-| `user` | Object specifying the User submitting their credentials | yes |
-| `user.email`      | user's email      | yes      |
-| `user.firstName`  | user's first name | yes      |
-| `user.lastName`   | user's last name  | yes      |
-| `user.zipCode`    | user's zip code   | no       |
-
+| Data field       | Description                                             | Required |
+| ---------------- | ------------------------------------------------------- | -------- |
+| `user`           | Object specifying the User submitting their credentials | yes      |
+| `user.email`     | user's email                                            | yes      |
+| `user.firstName` | user's first name                                       | yes      |
+| `user.lastName`  | user's last name                                        | yes      |
+| `user.zipCode`   | user's zip code                                         | no       |
 
 #### `config.data` for `scope: 'update'`
 
@@ -145,11 +144,10 @@ Example `config.data` when in the "updating user" flow:
 
 Data is expected in the following format for the `update` scope:
 
-| Data Field   | Description          | Required |
-| ------------ | -------------------- | -------- |
-| `user.id `   | User ID for user being updated | yes      |
-| `utilityCredential.id `  | User's UtilityCredential ID being updated | yes      |
-
+| Data Field              | Description                               | Required |
+| ----------------------- | ----------------------------------------- | -------- |
+| `user.id `              | User ID for user being updated            | yes      |
+| `utilityCredential.id ` | User's UtilityCredential ID being updated | yes      |
 
 ### `config.accessToken`
 
@@ -160,7 +158,6 @@ Note that the type of `accessToken` to be used depends on the user flow selected
 - For `scope: 'create'` configs, the `accessToken` must have been created with `scope: 'utility_connect', grant_type: 'client_credentials'`
 - For `scope: 'update'` configs, the `accessToken` must have been created with `scope: 'utility_connect', grant_type: 'password', user_id: xxx`
 
-
 ### `config.env`
 
 Determines which API the Utility Connect front-end points to
@@ -169,11 +166,9 @@ Determines which API the Utility Connect front-end points to
 - `sandbox`: This references our sandbox API. Use this in your development, staging or test environments.
 - `production`: This references our production API. **Only use this in your production app.**
 
-
 ### `config.client`
 
 The name used to reference the client organization.
-
 
 ### `config.callbacks`
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,11 @@ import { withUtilityConnect } from '@arcadia-eng/utility-connect-react';
 const config = { ... }; // See "Config Options" in the API Reference
 
 class CreateCredentials extends React.Component {
-  componentDidMount() {
-    this.props.utilityConnect.setData({ ... });
-    this.props.utilityConnect.setCallbacks({ ... });
-  }
-
   render() {
-    const { ready, error, open } = this.utilityConnect;
+    const { loading, error, open } = this.utilityConnect;
 
     return (
-      <button type="button" disabled={ready} onClick={() => open(config)}>
+      <button type="button" disabled={loading} onClick={() => open(config)}>
         Connect credentials
       </button>
     );

--- a/examples/hoc.js
+++ b/examples/hoc.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { number, shape, string } from 'prop-types';
+import { bool, number, shape, string } from 'prop-types';
 import { withUtilityConnect } from '@arcadia-eng/utility-connect-react';
 
 const config = {
@@ -19,22 +19,11 @@ const data = {
 class CreateCredentials extends React.Component {
   static propTypes = {
     utilityConnect: shape({
-      ready: bool.isRequired,
+      loading: bool.isRequired,
       error: object,
       open: func.isRequired,
-      setData: func.isRequired,
-      setCallbacks: func.isRequired,
     }),
   };
-
-  componentDidMount() {
-    this.props.utilityConnect.setData(data);
-    this.props.utilityConnect.setCallbacks({
-      onEmit: this.onEmit,
-      onOpen: this.onOpen,
-      onClose: this.onClose,
-    });
-  }
 
   onEmit = ({ error, data }) => {
     if (error) {
@@ -53,18 +42,18 @@ class CreateCredentials extends React.Component {
   };
 
   render() {
-    const { ready, error, open } = this.utilityConnect;
+    const { loading, error, open } = this.props.utilityConnect;
 
     if (error) {
       return <div>Failed to load credential widget: {error.message}</div>;
     }
 
     return (
-      <button type="button" disabled={ready} onClick={() => open(config)}>
+      <button type="button" disabled={loading} onClick={() => open(config)}>
         Connect credentials
       </button>
     );
   }
 }
 
-export default withUtilityConnect(CreateCredentials, config);
+export default withUtilityConnect(CreateCredentials);

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1095,6 +1095,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz",
+      "integrity": "sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
@@ -1775,6 +1785,190 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.31.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.6",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.13.0.tgz",
+      "integrity": "sha512-+jXXTn8GjRnZkJfzG/tqK/2Q7dGlBInR412WE7Aml7CT3wdSpx5dMQC0HOwVQoZ3cNTmQUy8fCVGUV/Zhoyvcw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
+      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
@@ -1788,6 +1982,15 @@
         "react-error-boundary": "^3.1.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.1.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
+      "integrity": "sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -1798,6 +2001,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+      "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
       "dev": true
     },
     "@types/babel__core": {
@@ -1910,6 +2119,131 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.6.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.6.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -1998,6 +2332,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.11.1",
@@ -2470,6 +2813,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
     "array-includes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
@@ -2531,6 +2884,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "babel-eslint": {
@@ -2952,6 +3311,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+      "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2962,6 +3327,31 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssom": {
       "version": "0.4.4",
@@ -3016,6 +3406,12 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
       "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "dedent": {
@@ -3103,6 +3499,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
+      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
+      "dev": true
     },
     "domexception": {
       "version": "2.0.1",
@@ -3612,6 +4014,17 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
+      }
+    },
+    "eslint-plugin-jest-dom": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-3.9.0.tgz",
+      "integrity": "sha512-Ou3cuAAY9s6pYZv+KKPa9XquSzUAWW2CgE5al7cQ0yew25w/kp5kNsUJgESb3Pj00Y6pzvznepppL2sk7UOQKg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "@testing-library/dom": "^7.28.1",
+        "requireindex": "^1.2.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -4167,6 +4580,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -6102,6 +6521,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6169,6 +6594,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimatch": {
@@ -6733,6 +7164,16 @@
         "resolve": "^1.9.0"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -6826,6 +7267,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "resolve": {
@@ -7041,6 +7488,16 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
+      }
+    },
     "source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -7190,6 +7647,15 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "@babel/plugin-transform-runtime": "^7.12.15",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
+    "@testing-library/jest-dom": "^5.13.0",
+    "@testing-library/react": "^11.2.7",
     "@testing-library/react-hooks": "^7.0.0",
+    "@testing-library/user-event": "^13.1.9",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "^3.0.0",
@@ -41,6 +44,7 @@
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-jest-dom": "^3.9.0",
     "eslint-plugin-prettier": "^3.2.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
@@ -61,12 +65,16 @@
     "react-script-hook": "^1.2.1"
   },
   "jest": {
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/test/"
+    ],
     "modulePaths": [
       "src",
       "test"
     ],
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/test/"
-    ]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest-setup.js"
+    ],
+    "testEnvironment": "jsdom"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "React tool for integrating with Arcadia's utility connect service",
   "main": "dist/index.js",
   "scripts": {

--- a/src/use-utility-connect.js
+++ b/src/use-utility-connect.js
@@ -3,10 +3,12 @@ import useScript from 'react-script-hook';
 
 const src = 'https://utility-connect-main.prod.arcadia.com/dist/v2.js';
 
-const scriptLoadError =
-  'Error fetching script - please check your internet connection.';
-const initializeError =
-  'Error loading Arcadia utility connect service - we are working to fix the issue.';
+const scriptLoadError = new Error(
+  'Error fetching script - please check your internet connection.'
+);
+const initializeError = new Error(
+  'Error loading Arcadia utility connect service - we are working to fix the issue.'
+);
 
 const getConfigError = errors => {
   const message = Object.values(errors).join(' ');
@@ -32,7 +34,7 @@ export const useUtilityConnect = () => {
 
     const { _ArcadiaUtilityConnect } = window;
     if (!_ArcadiaUtilityConnect) {
-      setError(new Error(initializeError));
+      setError(initializeError);
     } else {
       setFactory(window._ArcadiaUtilityConnect);
     }

--- a/src/with-utility-connect.js
+++ b/src/with-utility-connect.js
@@ -1,25 +1,13 @@
 import React, { useState } from 'react';
 import { useUtilityConnect } from './use-utility-connect';
 
-export const withUtilityConnect = (Component, config) => props => {
-  const [data, setData] = useState(undefined);
-  const [callbacks, setCallbacks] = useState(undefined);
-
-  const [{ loading, error }, open] = useUtilityConnect({
-    ...config,
-    data,
-    callbacks,
-  });
-
-  const ready = !loading && !error && !!data && !!callbacks;
+export const withUtilityConnect = Component => props => {
+  const [{ loading, error }, open] = useUtilityConnect();
 
   const utilityConnect = {
-    ready,
     loading,
     error,
     open,
-    setData,
-    setCallbacks,
   };
 
   return <Component {...props} utilityConnect={utilityConnect} />;

--- a/test/use-utility-connect.test.js
+++ b/test/use-utility-connect.test.js
@@ -1,7 +1,7 @@
-import { useUtilityConnect } from '../src/use-utility-connect';
 import { act, renderHook } from '@testing-library/react-hooks';
 import useScript from 'react-script-hook';
 import { generateUseScriptMock } from './test-utils';
+import { useUtilityConnect } from '../src/use-utility-connect';
 
 jest.mock('react-script-hook', () => ({
   __esModule: true,
@@ -10,8 +10,11 @@ jest.mock('react-script-hook', () => ({
 
 describe('useUtilityConnect', () => {
   beforeEach(() => {
-    global.window = {};
     useScript.mockImplementation(generateUseScriptMock());
+  });
+
+  afterEach(() => {
+    delete global.window._ArcadiaUtilityConnect;
   });
 
   it('has the expected values on load', async () => {
@@ -32,7 +35,7 @@ describe('useUtilityConnect', () => {
     await waitFor(() => expect(result.current[0].loading).toEqual(false));
     [{ loading, error }] = result.current;
     expect(loading).toEqual(false);
-    expect(error).toMatch(/Error fetching script/);
+    expect(error.message).toMatch(/Error fetching script/);
   });
 
   it('returns the initialization error if the script loads but has trouble initializing', async () => {
@@ -118,7 +121,9 @@ describe('useUtilityConnect', () => {
       });
       const [{ loading, error }] = result.current;
       expect(loading).toEqual(false);
-      expect(error).toMatch(/Error loading Arcadia utility connect service/);
+      expect(error.message).toMatch(
+        /Error loading Arcadia utility connect service/
+      );
     });
 
     it('can pass an onClose function via the configuration to the utility connect component', async () => {

--- a/test/with-utility.connect.test.js
+++ b/test/with-utility.connect.test.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useScript from 'react-script-hook';
+import { generateUseScriptMock } from './test-utils';
+import { withUtilityConnect } from '../src/with-utility-connect';
+
+jest.mock('react-script-hook', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const generateSampleConfig = () => ({
+  env: 'sandbox',
+  client: 'Test Co.',
+  accessToken: 'this_is_a_super_secret_token',
+});
+
+class MockCredentialComponentClass extends React.Component {
+  render() {
+    const config = this.props.config ?? generateSampleConfig();
+    const { loading, error, open } = this.props.utilityConnect;
+    return (
+      <div>
+        {loading && <div>Loading...</div>}
+        {error && <div role="alert">{error.message}</div>}
+        <button type="button" disabled={loading} onClick={() => open(config)}>
+          {this.props.buttonLabel}
+        </button>
+      </div>
+    );
+  }
+}
+
+const MockCredentialComponentWithHOC = withUtilityConnect(
+  MockCredentialComponentClass
+);
+
+describe('withUtilityConnect', () => {
+  let props;
+  beforeEach(() => {
+    useScript.mockImplementation(generateUseScriptMock());
+    props = { buttonLabel: 'Click me!' };
+  });
+
+  afterEach(() => {
+    delete global.window._ArcadiaUtilityConnect;
+  });
+
+  it("can forward props to the component it's wrapping", () => {
+    render(<MockCredentialComponentWithHOC {...props} />);
+    expect(
+      screen.getByRole('button', { name: 'Click me!' })
+    ).toBeInTheDocument();
+  });
+
+  it('properly passes loading and error on initialization', () => {
+    render(<MockCredentialComponentWithHOC {...props} />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('passes an error if the script fails to load', async () => {
+    useScript.mockImplementation(
+      generateUseScriptMock({ throwScriptError: true })
+    );
+    render(<MockCredentialComponentWithHOC {...props} />);
+    const alert = await screen.findByRole('alert');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(alert).toHaveTextContent(/Error fetching script/);
+  });
+
+  it('returns the initialization error if the script loads but has trouble initializing', async () => {
+    useScript.mockImplementation(
+      generateUseScriptMock({ loadArcadiaElementSuccessfully: false })
+    );
+    render(<MockCredentialComponentWithHOC {...props} />);
+    const alert = await screen.findByRole('alert');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(alert).toHaveTextContent(
+      /Error loading Arcadia utility connect service/
+    );
+  });
+
+  describe('calling open', () => {
+    let mockConfig;
+    beforeEach(() => {
+      mockConfig = generateSampleConfig();
+    });
+
+    const clickOpen = async () => {
+      await waitFor(() => expect(screen.getByRole('button')).toBeEnabled());
+      userEvent.click(screen.getByRole('button', { name: 'Click me!' }));
+      await waitForElementToBeRemoved(screen.getByText('Loading...'));
+    };
+
+    it('can call open', async () => {
+      render(<MockCredentialComponentWithHOC {...props} />);
+      await clickOpen();
+      expect(window._ArcadiaUtilityConnect.create).toHaveBeenCalledWith(
+        expect.objectContaining(mockConfig)
+      );
+    });
+
+    it("validates the configuration, and, if it's invalid, it throws an error", async () => {
+      useScript.mockImplementation(
+        generateUseScriptMock({ validationErrors: true })
+      );
+      render(<MockCredentialComponentWithHOC {...props} />);
+      await clickOpen();
+      expect(window._ArcadiaUtilityConnect.validate).toHaveBeenCalledWith(
+        mockConfig
+      );
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(/Error setting configuration variables/);
+      expect(alert).toHaveTextContent(/Missing \"accessToken\" value/);
+      expect(alert).toHaveTextContent(/Missing \"client\" value/);
+      expect(window._ArcadiaUtilityConnect.create).not.toHaveBeenCalled();
+    });
+
+    it("shows an error if Arcadia's create function fails for any reason", async () => {
+      useScript.mockImplementation(
+        generateUseScriptMock({ createError: true })
+      );
+      render(<MockCredentialComponentWithHOC {...props} />);
+      await clickOpen();
+      expect(window._ArcadiaUtilityConnect.validate).toHaveBeenCalledWith(
+        mockConfig
+      );
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(
+        /Error loading Arcadia utility connect service/
+      );
+    });
+
+    it('can pass an onClose function via the configuration to the utility connect component', async () => {
+      mockConfig = { callbacks: { onClose: jest.fn() } };
+      props.config = mockConfig;
+
+      render(<MockCredentialComponentWithHOC {...props} />);
+      await clickOpen();
+      const initializationObject =
+        window._ArcadiaUtilityConnect.create.mock.calls[0][0];
+      await act(async () => {
+        await initializationObject.callbacks.onClose();
+      });
+      expect(mockConfig.callbacks.onClose).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- Cleans up the Utility Connect HOC, so it's no longer using props that don't exist
- Full test coverage for the Utility Connect HOC
- Install jest dependencies
- Fixes the error type in the `use-utility-connect` hook so it returns a proper error object each time.