### PR TITLE
[Patch] Handle issues with widget loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/utility-connect-react",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "React tool for integrating with Arcadia's utility connect service",
   "main": "dist/index.js",
   "scripts": {

--- a/src/use-utility-connect.js
+++ b/src/use-utility-connect.js
@@ -56,6 +56,14 @@ export const useUtilityConnect = () => {
   useEffect(() => {
     if (scriptLoading || scriptError) return;
 
+    /**
+     * Note: 2021-07-13
+     * There is an issue with the underlying package where sometimes scriptLoading
+     * will be false while the script is still executing (https://github.com/hupe1980/react-script-hook/issues/17)
+     *
+     * Because of this issue, we should poll for the factory for a short period
+     * of time before returning an error
+     */
     pollForFactory();
 
     return () => clearTimeout(pollForFactoryTimeout.current);


### PR DESCRIPTION
## Issue
While playing around with flex-funnels, I found ran into an issue that's described here:
https://github.com/hupe1980/react-script-hook/issues/17
Basically, there are cases where the script is loaded from the cache, but is not "initialized" in time for the check in this useEffect:
```
 useEffect(() => {
    if (scriptLoading || scriptError) return;

    const { _ArcadiaUtilityConnect } = window;
    if (!_ArcadiaUtilityConnect) {
      setError(initializeError);
    } else {
      setFactory(window._ArcadiaUtilityConnect);
    }
  }, [scriptLoading, scriptError]);
  ```
  
  ## Solution
I modified the package so it now polls for the window object for a short period of time before throwing an error. I think this is the easiest way to tackle it for now.

## How to test
Existing tests should cover regression cases, but you can play around with this in the enterprise demo and try to break it. Flex funnels is decently annoying to set up with this, so I want to say "just trust me", but if you want to compare against my branch, DM me.
