### PR TITLE
fix callback doc formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ Determines which API the Utility Connect front-end points to
 Callback functions triggered at key points in the Utility Connect flow. Expects an object with key/value pairs where keys are as documented below.
 
 **`onCredentialsSubmitted`**: callback function that is triggered when the user has clicked the button to submit their credentials. Passes along an object with `utilityCredentialId` which can optionally be used by the containing application to poll the status of credential verification via the client's backend (which has awareness of the associated `client_user_id`).
+
 **`onOpen`**: callback function that is triggered when the Utility Connect component is opened.
+
 **`onError`**: callback function that is triggered when an error occurs during the Utility Connect flow.
+
 **`onClose`**: callback function that is triggered when the Utility Connect is closed. The user could have closed it by clicking outside the modal or clicking a button to dismiss the modal after an error, a successful credential validation or a timeout. Provided `status` string parameter indicates the final credential submission state when Utility Component was closed. If Utility Connect was manually closed via the `close` function, the latest credential submission state will be returned. Possible states:
 
 - `'verified'` : the credentials were confirmed to be correct


### PR DESCRIPTION
Not sure why but this was rendering weird without lines in between.

Before:

![image](https://user-images.githubusercontent.com/18612/126838988-8868f0b5-996e-40d8-a4a0-64b8733a0849.png)

After:

![image](https://user-images.githubusercontent.com/18612/126838931-ac5aef4f-4054-40e7-abc1-a4be3f9f7304.png)
