### PR TITLE
Update product naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+# Please note: this package is only applicable to the Legacy Arcadia Platform.
+
 # @arcadia-eng/connect-react
 
-Arcadia's general Developer Platform API documentation can be found at [docs.arcadia.com](https://docs.arcadia.com). The purpose of this package is to embed a user-facing interface where your customers can securely enter their utility credentials. The submission of user's utility-related credentials will create UtilityCredentials and UtilityAccounts that can be managed through the Arc API.
+Arcadia's general Developer Platform API documentation can be found at [docs.arcadia.com](https://docs.arcadia.com). The purpose of this package is to embed a user-facing interface where your customers can securely enter their utility credentials. The submission of user's utility-related credentials will create UtilityCredentials and UtilityAccounts that can be managed through the Arcadia API.
 
-This package is a React wrapper around Arc's Connect. It provides two ways to integrate the component into your React application - via hooks and via HoCs (higher order components).
+This package is a React wrapper around Arcadia's Connect. It provides two ways to integrate the component into your React application - via hooks and via HoCs (higher order components).
 
-As an alternative to using this package, Arc’s Connect can also be presented to your user through a URL. A Connect URL can be generated through [this endpoint](https://docs.arcadia.com/reference/createconnecturl). The URL approach differs from this React package in that the URL does not have any [config options](https://github.com/ArcadiaPower/connect-react#config-options) and does not respond with [callbacks](https://github.com/ArcadiaPower/connect-react#configcallbacks) for an application to interpret.
+As an alternative to using this package, Arcadia’s Connect can also be presented to your user through a URL. A Connect URL can be generated through [this endpoint](https://docs.arcadia.com/v2022-10-13/reference/createconnecturl). The URL approach differs from this React package in that the URL does not have any [config options](https://github.com/ArcadiaPower/connect-react#config-options) and does not respond with [callbacks](https://github.com/ArcadiaPower/connect-react#configcallbacks) for an application to interpret.
 
 # Installation
 
@@ -22,7 +24,7 @@ yarn add @arcadia-eng/connect-react
 
 # Quick Start
 
-A Connect Token is required to instantiate Connect. See [Getting a Connect Token to initialize Connect](https://docs.arcadia.com/docs#getting-a-connect-token-to-initialize-connect) for instructions. Keep in mind the following:
+A Connect Token is required to instantiate Connect. See [Getting a Connect Token to initialize Connect](https://docs.arcadia.com/v2022-10-13/docs/connect-guide#getting-a-connect-token-to-initialize-connect) for instructions. Keep in mind the following:
 
 - A general Access Token will not work to instantiate Connect
 - Using sandbox API keys to create a Connect Token will create resources in the sandbox environment
@@ -84,10 +86,10 @@ Please note that this package is still under active development and the API is s
 
 | Name                | Type     | Description                                                                     | Options | Required | Default |
 | ------------------- | -------- | ------------------------------------------------------------------------------- | ------- | -------- | ------- |
-| `connectToken`      | `string` | [Connect Token](https://docs.arcadia.com/reference/createconnecttoken) |         | Yes      | none    |
+| `connectToken`      | `string` | [Connect Token](https://docs.arcadia.com/v2022-10-13/reference/createconnecttoken) |         | Yes      | none    |
 | `newCredentialData` | `object` | Data used to prefill new credentials - only available in 'create' mode          |         | No       | none    |
 | `callbacks`         | `object` | Callback functions                                                              |         | No       | none    |
-| `variant`           | `string` | Set to 'tariff' if using [tariff selection mode](https://docs.arcadia.com/docs/connect-tariff-selection-mode)  |'tariff' or 'connect'        | No       | 'connect'    |
+| `variant`           | `string` | Set to 'tariff' if using [tariff selection mode](https://docs.arcadia.com/v2022-10-13/docs/connect-tariff-selection-mode)  |'tariff' or 'connect'        | No       | 'connect'    |
 
 ### `config.newCredentialData`
 
@@ -111,7 +113,7 @@ Data is expected in the following format:
 
 ### `config.ConnectToken`
 
-An access token to create or update credentials. See [Getting a Connect Token to initialize Connect](https://docs.arcadia.com/docs#getting-a-connect-token-to-initialize-connect) for more details on how to create a Connect Token.
+An access token to create or update credentials. See [Getting a Connect Token to initialize Connect](https://docs.arcadia.com/v2022-10-13/docs/connect-guide#getting-a-connect-token-to-initialize-connect) for more details on how to create a Connect Token.
 
 ### `config.callbacks`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadia-eng/connect-react",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "React package for implementing Legacy Arcadia Connect",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcadia-eng/connect-react",
   "version": "7.2.0",
-  "description": "React package for implementing Arc Connect",
+  "description": "React package for implementing Legacy Arcadia Connect",
   "main": "dist/index.js",
   "scripts": {
     "docz:dev": "./node_modules/.bin/docz dev",

--- a/src/use-connect.js
+++ b/src/use-connect.js
@@ -35,9 +35,9 @@ export const useConnect = () => {
   });
 
   const pollForFactory = useCallback(() => {
-    const { _ArcConnect } = window;
-    if (_ArcConnect) {
-      setFactory(_ArcConnect);
+    const { _ArcadiaConnect } = window;
+    if (_ArcadiaConnect) {
+      setFactory(_ArcadiaConnect);
       return;
     }
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -42,7 +42,7 @@ export const generateUseScriptMock = ({
         if (throwScriptError) {
           setScriptError(new Error('Something went wrong'));
         } else if (loadArcadiaElementSuccessfully) {
-          window._ArcConnect = mockConnect;
+          window._ArcadiaConnect = mockConnect;
         }
       };
       simulateLoad();

--- a/test/use-connect.test.js
+++ b/test/use-connect.test.js
@@ -14,7 +14,7 @@ describe('useConnect', () => {
   });
 
   afterEach(() => {
-    delete global.window._ArcConnect;
+    delete global.window._ArcadiaConnect;
   });
 
   it('has the expected values on load', async () => {
@@ -61,7 +61,7 @@ describe('useConnect', () => {
       await act(async () => {
         await open(sampleConfig);
       });
-      expect(window._ArcConnect.create).toHaveBeenCalledWith(
+      expect(window._ArcadiaConnect.create).toHaveBeenCalledWith(
         expect.objectContaining(sampleConfig)
       );
     });
@@ -76,9 +76,9 @@ describe('useConnect', () => {
       await act(async () => {
         await open(sampleConfig);
       });
-      expect(window._ArcConnect).toBeUndefined();
-      await waitFor(() => expect(window._ArcConnect).not.toBeUndefined());
-      expect(window._ArcConnect.create).toHaveBeenCalledWith(
+      expect(window._ArcadiaConnect).toBeUndefined();
+      await waitFor(() => expect(window._ArcadiaConnect).not.toBeUndefined());
+      expect(window._ArcadiaConnect.create).toHaveBeenCalledWith(
         expect.objectContaining(sampleConfig)
       );
     });
@@ -96,11 +96,11 @@ describe('useConnect', () => {
       });
       const [{ loading, error }] = result.current;
       expect(loading).toEqual(false);
-      expect(window._ArcConnect.validate).toHaveBeenCalledWith(sampleConfig);
+      expect(window._ArcadiaConnect.validate).toHaveBeenCalledWith(sampleConfig);
       expect(error.message).toMatch(/Error setting configuration variables/);
       expect(error.message).toMatch(/Missing \"connectToken\" value/);
       expect(error.message).toMatch(/Missing \"somethingImportant\" value/);
-      expect(window._ArcConnect.create).not.toHaveBeenCalled();
+      expect(window._ArcadiaConnect.create).not.toHaveBeenCalled();
     });
 
     it("shows an error if Arcadia's create function fails for any reason", async () => {
@@ -126,7 +126,7 @@ describe('useConnect', () => {
       await act(async () => {
         await open(sampleConfig);
       });
-      const initializationObject = window._ArcConnect.create.mock.calls[0][0];
+      const initializationObject = window._ArcadiaConnect.create.mock.calls[0][0];
       act(() => {
         initializationObject.callbacks.onClose();
       });
@@ -143,9 +143,9 @@ describe('useConnect', () => {
       it('can close the factory when the factory is loaded', async () => {
         const { result, unmount, waitFor } = renderHook(() => useConnect());
         await waitFor(() => expect(result.current[0].loading).toEqual(false));
-        expect(window._ArcConnect.close).toHaveBeenCalledTimes(0);
+        expect(window._ArcadiaConnect.close).toHaveBeenCalledTimes(0);
         unmount();
-        expect(window._ArcConnect.close).toHaveBeenCalledTimes(1);
+        expect(window._ArcadiaConnect.close).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/test/with-connect.test.js
+++ b/test/with-connect.test.js
@@ -48,7 +48,7 @@ describe('withConnect', () => {
   });
 
   afterEach(() => {
-    delete global.window._ArcConnect;
+    delete global.window._ArcadiaConnect;
   });
 
   it("can forward props to the component it's wrapping", () => {
@@ -99,7 +99,7 @@ describe('withConnect', () => {
     it('can call open', async () => {
       render(<MockCredentialComponentWithHOC {...props} />);
       await clickOpen();
-      expect(window._ArcConnect.create).toHaveBeenCalledWith(
+      expect(window._ArcadiaConnect.create).toHaveBeenCalledWith(
         expect.objectContaining(mockConfig)
       );
     });
@@ -110,12 +110,12 @@ describe('withConnect', () => {
       );
       render(<MockCredentialComponentWithHOC {...props} />);
       await clickOpen();
-      expect(window._ArcConnect.validate).toHaveBeenCalledWith(mockConfig);
+      expect(window._ArcadiaConnect.validate).toHaveBeenCalledWith(mockConfig);
       const alert = screen.getByRole('alert');
       expect(alert).toHaveTextContent(/Error setting configuration variables/);
       expect(alert).toHaveTextContent(/Missing \"connectToken\" value/);
       expect(alert).toHaveTextContent(/Missing \"somethingImportant\" value/);
-      expect(window._ArcConnect.create).not.toHaveBeenCalled();
+      expect(window._ArcadiaConnect.create).not.toHaveBeenCalled();
     });
 
     it("shows an error if Arcadia's create function fails for any reason", async () => {
@@ -124,7 +124,7 @@ describe('withConnect', () => {
       );
       render(<MockCredentialComponentWithHOC {...props} />);
       await clickOpen();
-      expect(window._ArcConnect.validate).toHaveBeenCalledWith(mockConfig);
+      expect(window._ArcadiaConnect.validate).toHaveBeenCalledWith(mockConfig);
       const alert = screen.getByRole('alert');
       expect(alert).toHaveTextContent(/Error loading Connect/);
     });
@@ -135,7 +135,8 @@ describe('withConnect', () => {
 
       render(<MockCredentialComponentWithHOC {...props} />);
       await clickOpen();
-      const initializationObject = window._ArcConnect.create.mock.calls[0][0];
+      const initializationObject =
+        window._ArcadiaConnect.create.mock.calls[0][0];
       await act(async () => {
         await initializationObject.callbacks.onClose();
       });
@@ -156,9 +157,9 @@ describe('withConnect', () => {
           <MockCredentialComponentWithHOC {...props} />
         );
         await clickOpen();
-        expect(window._ArcConnect.close).toHaveBeenCalledTimes(0);
+        expect(window._ArcadiaConnect.close).toHaveBeenCalledTimes(0);
         unmount();
-        expect(window._ArcConnect.close).toHaveBeenCalledTimes(1);
+        expect(window._ArcadiaConnect.close).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
Updates product naming to mostly use "Arcadia Connect" or "Legacy Arcadia Platform".

After merging to main, I'll need to `npm run build` and then `npm publish --access public`